### PR TITLE
Changed error report format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const validatorJS = require('validator');
 const validatorKeys = Object.keys(validatorJS).filter(key => key.startsWith('is'));
 validatorKeys.push('contains', 'equals', 'matches');
 
-let errors = [];
+let errors = {};
 
 module.exports = {
   validator(rules, next) {
@@ -13,10 +13,10 @@ module.exports = {
         func.exec(args);
       });
 
-      if (errors.length > 0) {
+      if (errors.hasError) {
         const ctx = context;
         ctx.validationErrors = errors;
-        errors = [];
+        errors = {};
       }
 
       return next(parent, args, context, info);
@@ -56,12 +56,14 @@ module.exports = {
           const isError = !obj.isNegateNext ? !validationResult : validationResult;
 
           if (isError) {
-            const validationError = {
-              param,
-              msg: config.msg || 'Invalid value',
-            };
-
-            errors.push(validationError);
+            const msg = config.msg || 'Invalid value'
+            if (errors[param]) {
+              errors[param].push(msg)
+            }
+            else {
+              errors[param] = [msg];
+            }
+            errors.hasError = true;
           }
 
           obj.isNegateNext = false;


### PR DESCRIPTION
The Error report shall be better if it's an Object and each parameter should be a key and they hold an array with all the errors related to the parameter. Something like:

```
context.validationErrors = {
   'id': ['MongoId is invalid']
   'title': ['Title is invalid', 'Title must contains \"hi\"', 'Title is required']
   'content': ['Invalid value']
}
```